### PR TITLE
Tweak "firmware extraction methods"

### DIFF
--- a/hardware-hacking/basics/firmware-extraction-methods.md
+++ b/hardware-hacking/basics/firmware-extraction-methods.md
@@ -8,7 +8,7 @@ icon: browser
 
 Firmware is the software embedded in a device's hardware, often critical for its operation. Extracting and analyzing it is crucial to understqnd the device's functionality and structure and establish a foothold by analysing, through methods of reverse engineering, or modifying the firmware and reflashing a device.
 
-But before you fire up [Binwalk](https://github.com/ReFirmLabs/binwalk) or [Ghidra](https://github.com/NationalSecurityAgency/ghidra) and start analyzing, reversing and establishing your foothold, you first need to obtain the firmware itself.
+But before you fire up [Binwalk](/hardware-hacking/basics/tools/software-tools/binwalk.md) or [Ghidra](/hardware-hacking/basics/tools/software-tools/ghidra.md) and start analyzing, reversing and establishing your foothold, you first need to obtain the firmware itself.
 
 Obtaining the firmware from devices can be done in several different ways. Depending on the target device, firmware can be extracted through physical, semi-physical, or software-only methods. This page covers both invasive and non-invasive approaches.
 
@@ -80,7 +80,7 @@ These approaches require minimal physical interaction with the device but stop s
 Depending on the interface that is exposed, various different tools might be required:
 
 * USB-to-UART adapters.
-* Debugging software (e.g., OpenOCD for JTAG).
+* Debugging software (e.g., [OpenOCD](/hardware-hacking/basics/tools/software-tools/openocd.md) for JTAG).
 
 **Step to extracting the firmware through an exposed interface**
 

--- a/hardware-hacking/basics/firmware-extraction-methods.md
+++ b/hardware-hacking/basics/firmware-extraction-methods.md
@@ -43,7 +43,7 @@ Although many devices use HTTPS, complicating the process of intercepting, it is
 **Tools required**
 
 * Packet capture tools (e.g., Wireshark) to monitor and intercept update traffic.
-* Proxies (e.g., mitmproxy, [mitmrouter](https://github.com/nmatt0/mitmrouter)) to redirect and inspect update requests and device network traffic.
+* Proxies (e.g., mitmproxy, [mitmrouter](/hardware-hacking/basics/tools/software-tools/mitmrouter.md)) to redirect and inspect update requests and device network traffic.
 
 **Steps of a MitM attack on the OTA update process**
 

--- a/hardware-hacking/basics/firmware-extraction-methods.md
+++ b/hardware-hacking/basics/firmware-extraction-methods.md
@@ -87,10 +87,10 @@ Depending on the interface that is exposed, various different tools might be req
 1. Locate debug interfaces on the device’s casing or accessible panels.
 2. Use appropriate tools and protocol to interact with the interface and extract the firmware as detailed within the various pages below:
 
-* UART
-* SPI
-* JTAG/SWD
-* I2C
+* [UART](/hardware-hacking/interface-interaction/uart/extract-firmware-using-uart.md)
+* [SPI](/hardware-hacking/interface-interaction/spi/extract-firmware-using-spi.md)
+* [JTAG/SWD](/hardware-hacking/interface-interaction/jtag-swd/extract-firmware-using-jtag-swd.md)
+* [I2C](/hardware-hacking/interface-interaction/i2c.md)
 
 ### Invasive Methods
 

--- a/hardware-hacking/basics/tools/software-tools/mitmrouter.md
+++ b/hardware-hacking/basics/tools/software-tools/mitmrouter.md
@@ -1,0 +1,6 @@
+# MITM Router
+Bash script to automate setup of Linux router useful for IoT device traffic analysis and SSL mitm 
+
+Tool made by [Matt Brown](https://github.com/nmatt0)
+
+Repository: https://github.com/nmatt0/mitmrouter


### PR DESCRIPTION
- Link tools to internal
- fix links for UART, SPI, JTAG/SWD, I2C within the page
- Added page for mitmrouter tool (this might have broken), and link to it within the page