### PR TITLE
Remove duplicate paragraph in introduction case study

### DIFF
--- a/introduction/case-study-led-to-a-cve-update/README.md
+++ b/introduction/case-study-led-to-a-cve-update/README.md
@@ -15,8 +15,6 @@ I stumbled across an old **Asus RT-N12 D1 router** in my basement, which had bee
 
 The first step in any hardware hacking project is research. I started by Googling the router model number, **"ASUS RT-N12 D1"**, and came across an [article](https://redfoxsec.com/blog/asus-rt-n12-b1s-privilege-escalation-cve-2024-28326/) about a similar model, the **ASUS RT-N12+ B1**. The article mentioned that the device had an open **UART interface** allowing **unauthenticated root access**. However, it provided no exact details on how to exploit this or where the UART interface might be located. Could my router model have the same vulnerability?
 
-In the first step I googled the model number for my router "ASUS RT N12 D1" and I came accross this [article](https://redfoxsec.com/blog/asus-rt-n12-b1s-privilege-escalation-cve-2024-28326/). It shows that a similar model the  "ASUS RT N12+ B1" appears to have an open UART interface, which gives unauthenticated root access. It does not show how to exacltly abuse this or any details where to find the UART interface.  Let's see if our router model may have the same vulnerability!
-
 To gather more information, I turned to the **FCC ID** printed on the back of the router:
 
 <figure><img src="../../.gitbook/assets/image (79).png" alt="" width="383"><figcaption><p>FCC ID</p></figcaption></figure>


### PR DESCRIPTION
Same information appears twice but worded differently. I suggest keeping the first one which has a more professional tone.